### PR TITLE
[fix]カート内が空の時、注文住所選択挙動修正

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -1,8 +1,13 @@
 class Public::OrdersController < ApplicationController
   def new
-    @order = Order.new
-    # @customer = Order.customer.find(params[:id])
-    @shipping_addresses = current_customer.shipping_addresses.all
+    @carts = current_customer.carts
+    
+    if @carts.any?
+      @order = Order.new
+      @shipping_addresses = current_customer.shipping_addresses.all
+    end
+    
+    redirect_to carts_path #今現在のページ
   end
 
   def create
@@ -38,10 +43,10 @@ class Public::OrdersController < ApplicationController
 
         # collection.selectであれば
       elsif params[:order][:address_option] == "1"
-        ship = ShippingAddress.find(params[:order][:customer_id])
-        @order.ships_post_number = ship.post_number
-        @order.ships_address = ship.address
-        @order.ships_name = ship.name
+        ship = ShippingAddress.find_by(params[:order][:customer_id])
+        @order.ships_post_number = ship.ships_post_number
+        @order.ships_address = ship.ships_address
+        @order.ships_name = ship.ships_name
 
         # 新規住所入力であれば
       elsif params[:order][:address_option] == "2"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,8 +15,8 @@ ActiveRecord::Schema.define(version: 2023_05_15_075045) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2023_05_15_075045) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end


### PR DESCRIPTION
カート内が空の時に、注文情報入力画面に飛べないように修正。
注文情報入力画面で、登録済み住所を選択した際に、エラーが出ないように修正いたしました。