### PR TITLE
admin ビュー日付調整 ログアウト後の移管画面編集

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -19,6 +19,10 @@ class Admin::SessionsController < Devise::SessionsController
   end
 
   # protected
+  #管理者のログアウト後の移管画面指定
+  def after_sign_out_path_for(resource)
+    new_admin_session_path
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -11,7 +11,7 @@
     <% @orders.reverse.each do |order| %>
     <tr>
       <!--購入日時をクリックで注文履歴詳細へ飛ぶ-->
-      <td><%= link_to admin_order_path(order) do %><%= order.created_at.strftime("%Y%m%d") %><% end %></td>
+      <td><%= link_to admin_order_path(order) do %><%= order.created_at.strftime("%Y/%m/%d") %><% end %></td>
       <!--customerモデルのcustomer_nameメソッドを使用-->
       <td><%= order.customer.customer_name %></td>
       <!--注文詳細から注文個数を呼び出し-->

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <%= flash[:notice] %>
   <h2>商品詳細</h2>
   <div class="row">
     <div class="col-md-3 mr-5">

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -6,18 +6,19 @@
     <tr>
       <td>購入者</td>
       <td>
-        <%= link_to admin_customer_path do %>
+        <%= link_to admin_customer_path(@order.customer) do %>
         <%= @order.customer.customer_name %>
         <% end %>
       </td>
     </tr>
     <tr>
       <td>注文日</td>
-      <td><%= @order.created_at.strftime("%Y%m%d") %></td>
+      <td><%= @order.created_at.strftime("%Y/%m/%d") %></td>
     </tr>
     <tr>
       <td>配送先</td>
       <td>
+        〒
         <%= @order.ships_post_number %>
         <%= @order.ships_address %><br>
         <%= @order.ships_name%>


### PR DESCRIPTION
admin 側の　注文詳細、注文履歴一覧画面の日付に/を入れました。
ログアウト後の移管画面を管理者ログイン画面に設定しました。
注文詳細画面の注文者の名前をクリックした際の移管先のリンクを正しいものに修正しました。